### PR TITLE
Accept stop documents with no 'reason'.

### DIFF
--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -531,6 +531,7 @@ class Serializer(event_model.DocumentRouter):
 
     def stop(self, doc):
         msg = '\n'
+        doc.setdefault('reason', 'No reason recorded.')
         if doc['exit_status'] != 'success':
             msg += ('#C Run exited with status: {exit_status}. Reason: '
                     '{reason}'.format(**doc))


### PR DESCRIPTION
The 'reason' key is not required by the schema, and we found some
documents at CHX that do not have it.

It's a separate question how we are ending up with documents that have
an 'exit_status' other than 'success' by no 'reason'. The RunEngine
should be ensuring that. Nonetheless, this suitcase should be tolerant
of any document that meets the schema, so this change is correct.