### PR TITLE
Corrected SPEC header formation from bluesky start doc

### DIFF
--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -152,7 +152,7 @@ def _get_plan_name(start):
 
 def _get_motor_name(start):
     plan_name = _get_plan_name(start)
-    if (plan_name not in _BLUESKY_PLAN_NAMES or
+    if (plan_name not in _SPEC_SCAN_NAMES or
             plan_name in _SCANS_WITHOUT_MOTORS):
         return 'seq_num'
     motor_name = start['motors']
@@ -172,7 +172,7 @@ def _get_motor_name(start):
 def _get_motor_position(start, event):
     plan_name = _get_plan_name(start)
     # make sure we are trying to get the motor position for an implemented scan
-    if (plan_name not in _BLUESKY_PLAN_NAMES or
+    if (plan_name not in _SPEC_SCAN_NAMES or
             plan_name in _SCANS_WITHOUT_MOTORS):
         return event['seq_num']
     motor_name = _get_motor_name(start)
@@ -226,12 +226,21 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
     motor_name = _get_motor_name(start)
     acq_time = _get_acq_time(start)
     # can only grab start/stop/num if we are a dscan or ascan.
-    if (scan_command not in _BLUESKY_PLAN_NAMES or
+    if (scan_command not in _SPEC_SCAN_NAMES or
             scan_command in _SCANS_WITHOUT_MOTORS):
         command_args = []
     else:
-        command_args = [start['plan_args'][k]
-                        for k in ('start', 'stop', 'num')]
+        
+        
+        #command_args = [start['plan_args'][k]
+        #               for k in ('start', 'stop', 'num')]
+        # The scans scan and rel_scan don't contain keys 'start' and 'stop' they are just in a list
+        start_val = start['plan_args']['args'][-2]
+        stop_val = start['plan_args']['args'][-1]
+        num = start['plan_args']['num']
+        
+        command_args = [start_val,stop_val,num]
+        
     command_list = ([scan_command, motor_name] + command_args + [acq_time])
     # have to ensure all list elements are strings or join gets angry
     md['command'] = ' '.join([str(s) for s in command_list])


### PR DESCRIPTION
 the spec header was incorrectly being written as 'seq_num' rather than being populated with the plan name and the plan arguments even when the `plan_name` was in  `_BLUESKY_PLAN_NAMES`. I corrected this by checking the `scan_command` was in _SPEC_SCAN_NAMES rather than _BLUESKY_PLAN_NAMES. I then changed the `command_args` calculation to assume that `args` was a list and not a dict since this is what is implemented for the [scan](https://nsls-ii.github.io/bluesky/_modules/bluesky/plans.html#scan) and [rel_scan](https://nsls-ii.github.io/bluesky/_modules/bluesky/plans.html#rel_scan) plans. Tested by running scans and opening them in pyMca