### PR TITLE
Multiple motors

### DIFF
--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -229,18 +229,15 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
     if (scan_command not in _SPEC_SCAN_NAMES or
             scan_command in _SCANS_WITHOUT_MOTORS):
         command_args = []
+
     else:
-        
-        
-        #command_args = [start['plan_args'][k]
-        #               for k in ('start', 'stop', 'num')]
-        # The scans scan and rel_scan don't contain keys 'start' and 'stop' they are just in a list
+
         start_val = start['plan_args']['args'][-2]
         stop_val = start['plan_args']['args'][-1]
         num = start['plan_args']['num']
-        
-        command_args = [start_val,stop_val,num]
-        
+
+        command_args = [start_val, stop_val, num]
+
     command_list = ([scan_command, motor_name] + command_args + [acq_time])
     # have to ensure all list elements are strings or join gets angry
     md['command'] = ' '.join([str(s) for s in command_list])

--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -160,7 +160,7 @@ def _get_motor_names(start):
     return motor_names
 
 
-def _get_motor_position(start, event):
+def _get_motor_positions(start, event):
     plan_name = _get_plan_name(start)
     # make sure we are trying to get the motor position for an implemented scan
     if (plan_name not in _SPEC_SCAN_NAMES or
@@ -174,9 +174,9 @@ def _get_motor_position(start, event):
     # if none of the above conditions are met, we can get a motor value. Thus we
     # return the motor value in the event
 
-    data = []
+    data = ""
     for motor in motor_name:
-        data.append(event['data'][motor])
+        data = data + str((event['data'][motor])) + ' ' 
     return data
 
 
@@ -274,7 +274,7 @@ def to_spec_scan_data(start, primary_descriptor, event):
     md = {}
     md['unix_time'] = int(event['time'])
     md['acq_time'] = _get_acq_time(start)
-    md['motor_position'] = ' '.join([str(s) for s in _get_motor_position(start, event)])
+    md['motor_position'] = _get_motor_positions(start, event)
     data_keys = _get_scan_data_column_names(start, primary_descriptor)
     md['values'] = [event['data'][k] for k in data_keys]
     return _SPEC_EVENT_TEMPLATE.render(md)

--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -176,7 +176,7 @@ def _get_motor_positions(start, event):
 
     data = ""
     for motor in motor_name:
-        data = data + str((event['data'][motor])) + ' ' 
+        data = data + str((event['data'][motor])) + ' '
     return data
 
 
@@ -228,6 +228,13 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
         motor_and_args = [motor_names, []]
 
     elif scan_command == 'mesh':
+
+        if len(motor_names) > 2:
+
+            raise NotImplementedError(
+             "Your scan has {0} scanning motors. They are {1}. mesh expects 2"
+             .format(len(motor_names), motor_names))
+        return 'seq_num'
 
         for motor in range(len(motor_names)):
 

--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -152,7 +152,7 @@ def _get_plan_name(start):
 
 def _get_motor_name(start):
     plan_name = _get_plan_name(start)
-    if (plan_name not in _BLUESKY_PLAN_NAMES or
+    if (plan_name not in _SPEC_SCAN_NAMES or
             plan_name in _SCANS_WITHOUT_MOTORS):
         return 'seq_num'
     motor_name = start['motors']
@@ -172,7 +172,7 @@ def _get_motor_name(start):
 def _get_motor_position(start, event):
     plan_name = _get_plan_name(start)
     # make sure we are trying to get the motor position for an implemented scan
-    if (plan_name not in _BLUESKY_PLAN_NAMES or
+    if (plan_name not in _SPEC_SCAN_NAMES or
             plan_name in _SCANS_WITHOUT_MOTORS):
         return event['seq_num']
     motor_name = _get_motor_name(start)
@@ -226,12 +226,21 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
     motor_name = _get_motor_name(start)
     acq_time = _get_acq_time(start)
     # can only grab start/stop/num if we are a dscan or ascan.
-    if (scan_command not in _BLUESKY_PLAN_NAMES or
+    if (scan_command not in _SPEC_SCAN_NAMES or
             scan_command in _SCANS_WITHOUT_MOTORS):
         command_args = []
     else:
-        command_args = [start['plan_args'][k]
-                        for k in ('start', 'stop', 'num')]
+        
+        
+        #command_args = [start['plan_args'][k]
+        #               for k in ('start', 'stop', 'num')]
+        # The scans scan and rel_scan don't contain keys 'start' and 'stop' they are just in a list
+        start_val = start['plan_args']['args'][-2]
+        stop_val = start['plan_args']['args'][-1]
+        num = start['plan_args']['num']
+        
+        command_args = [start_val,stop_val,num]
+        
     command_list = ([scan_command, motor_name] + command_args + [acq_time])
     # have to ensure all list elements are strings or join gets angry
     md['command'] = ' '.join([str(s) for s in command_list])

--- a/suitcase/specfile/__init__.py
+++ b/suitcase/specfile/__init__.py
@@ -100,9 +100,11 @@ def to_spec_file_header(start, filepath, baseline_descriptor=None):
 
 _SPEC_1D_COMMAND_TEMPLATE = env.from_string(
     "{{ plan_name }} {{ scan_motor }} {{ start }} {{ stop }} {{ num }} {{ time }}")
+_SPEC_2D_COMMAND_TEMPLATE = env.from_string(
+    "{{ plan_name }} {{ scan_motor }} {{ start }} {{ stop }} {{ num }} {{ scan_motor }} {{ start }} {{ stop }} {{ num }} {{ time }}")
 
 _SCANS_WITHOUT_MOTORS = {'ct': 'count'}
-_SCANS_WITH_MOTORS = {'ascan': 'scan', 'dscan': 'rel_scan'}
+_SCANS_WITH_MOTORS = {'ascan': 'scan', 'dscan': 'rel_scan', 'mesh':'grid_scan'}
 _SPEC_SCAN_NAMES = _SCANS_WITHOUT_MOTORS.copy()
 _SPEC_SCAN_NAMES.update(_SCANS_WITH_MOTORS)
 _BLUESKY_PLAN_NAMES = {v: k for k, v in _SPEC_SCAN_NAMES.items()}
@@ -150,23 +152,15 @@ def _get_plan_name(start):
     return get_name(plan_name)
 
 
+#returns a list of motor names
 def _get_motor_name(start):
     plan_name = _get_plan_name(start)
     if (plan_name not in _SPEC_SCAN_NAMES or
             plan_name in _SCANS_WITHOUT_MOTORS):
         return 'seq_num'
-    motor_name = start['motors']
-    # We only support a single scanning motor right now.
-    if len(motor_name) > 1:
-        raise NotImplementedError(
-            "Your scan has {0} scanning motors. They are {1}. Conversion to a"
-            "specfile does not understand what to do with multiple scanning. "
-            "Please request this feature at "
-            "https://github.com/NSLS-II/suitcase/issues Until this feature is "
-            "implemented, we will be using the sequence number as the motor "
-            "position".format(len(motor_name), motor_name))
-        return 'seq_num'
-    return motor_name[0]
+    motor_names = start['motors']
+    
+    return motor_names
 
 
 def _get_motor_position(start, event):
@@ -182,7 +176,11 @@ def _get_motor_position(start, event):
         return event['seq_num']
     # if none of the above conditions are met, we can get a motor value. Thus we
     # return the motor value in the event
-    return event['data'][motor_name]
+    
+    data = []
+    for motor in motor_name:
+        data.append(event['data'][motor])
+    return data
 
 
 def _get_scan_data_column_names(start, primary_descriptor):
@@ -190,7 +188,7 @@ def _get_scan_data_column_names(start, primary_descriptor):
     # List all scalar fields, excluding the motor (x variable).
     read_fields = sorted(
         [k for k, v in primary_descriptor['data_keys'].items()
-         if (v['object_name'] != motor_name and not v['shape'])])
+         if (v['object_name'] not in motor_name and not v['shape'])])
     return read_fields
 
 
@@ -223,23 +221,45 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
     md = {}
     md['scan_id'] = start['scan_id']
     scan_command = _get_plan_name(start)
-    motor_name = _get_motor_name(start)
+    motor_names = _get_motor_name(start)
     acq_time = _get_acq_time(start)
-    # can only grab start/stop/num if we are a dscan or ascan.
+    
+    
+    motor_and_args = []
     if (scan_command not in _SPEC_SCAN_NAMES or
             scan_command in _SCANS_WITHOUT_MOTORS):
-        command_args = []
 
+        motor_and_args  = [motor_names, []]
+        
+    elif scan_command == 'mesh':
+    
+        for motor in range(len(motor_names)):
+        
+            start_val =start['plan_args']['args'][1+motor*4]
+            stop_val = start['plan_args']['args'][2+motor*4]
+            num = int(start['plan_args']['args'][3+motor*4])-1
+            
+            motor_and_args = motor_and_args + [motor_names[motor], start_val,stop_val,num]
+    
     else:
+        
+        
+        for motor in range(len(motor_names)):
+        
+            start_val = start['plan_args']['args'][1+motor*3]
+            stop_val = start['plan_args']['args'][2+motor*3]
+                        
+            motor_and_args = motor_and_args + [motor_names[motor], start_val,stop_val]
+        
+        motor_and_args.append(start['plan_args']['num'])
+        
+        if len(motor_names)>1:
+            scan_command = scan_command[0] + str(len(motor_names)) + scan_command[1:]
+            
+    command_list = ([scan_command] + motor_and_args + [acq_time])
 
-        start_val = start['plan_args']['args'][-2]
-        stop_val = start['plan_args']['args'][-1]
-        num = start['plan_args']['num']
-
-        command_args = [start_val, stop_val, num]
-
-    command_list = ([scan_command, motor_name] + command_args + [acq_time])
     # have to ensure all list elements are strings or join gets angry
+    
     md['command'] = ' '.join([str(s) for s in command_list])
     md['readable_time'] = to_spec_time(datetime.fromtimestamp(start['time']))
     md['acq_time'] = acq_time
@@ -247,7 +267,7 @@ def to_spec_scan_header(start, primary_descriptor, baseline_event=None):
         v for k, v in sorted(baseline_event['data'].items())]
     md['data_keys'] = _get_scan_data_column_names(start, primary_descriptor)
     md['num_columns'] = 3 + len(md['data_keys'])
-    md['motor_name'] = _get_motor_name(start)
+    md['motor_name'] = '  '.join([str(s) for s in _get_motor_name(start)])           #deals with multiple motors, note double space ' '
     return _SPEC_SCAN_HEADER_TEMPLATE.render(md)
 
 
@@ -259,7 +279,7 @@ def to_spec_scan_data(start, primary_descriptor, event):
     md = {}
     md['unix_time'] = int(event['time'])
     md['acq_time'] = _get_acq_time(start)
-    md['motor_position'] = _get_motor_position(start, event)
+    md['motor_position'] = ' '.join([str(s) for s in _get_motor_position(start, event)]) 
     data_keys = _get_scan_data_column_names(start, primary_descriptor)
     md['values'] = [event['data'][k] for k in data_keys]
     return _SPEC_EVENT_TEMPLATE.render(md)

--- a/suitcase/specfile/tests/data_from_suitcase_v0.7.0/rel_scan.spec
+++ b/suitcase/specfile/tests/data_from_suitcase_v0.7.0/rel_scan.spec
@@ -5,15 +5,15 @@
 #O0 SIM:motor1  SIM:motor1_setpoint  SIM:motor2  SIM:motor2_setpoint
 #o0 motor1 motor1_setpoint motor2 motor2_setpoint
 
-#S 4 dscan seq_num -1
+#S 4 dscan motor -1 1 3 -1
 #D Wed Mar 06 11:01:18 2019
 #T -1  (Seconds)
 #P0 0 0 0 0
-#N 6
-#L seq_num  Epoch  Seconds  det  motor  motor_setpoint
-1  1551888078 -1 1.0 0.0 0.0
+#N 4
+#L motor  Epoch  Seconds  det
+0.0  1551888078 -1 1.0
 
-2  1551888078 -1 0.6065306597126334 1.0 1.0
+1.0  1551888078 -1 0.6065306597126334
 
-3  1551888078 -1 0.1353352832366127 2.0 2.0
+2.0  1551888078 -1 0.1353352832366127
 

--- a/suitcase/specfile/tests/data_from_suitcase_v0.7.0/scan.spec
+++ b/suitcase/specfile/tests/data_from_suitcase_v0.7.0/scan.spec
@@ -5,15 +5,15 @@
 #O0 SIM:motor1  SIM:motor1_setpoint  SIM:motor2  SIM:motor2_setpoint
 #o0 motor1 motor1_setpoint motor2 motor2_setpoint
 
-#S 3 ascan seq_num -1
+#S 3 ascan motor -1 1 3 -1
 #D Wed Mar 06 11:01:18 2019
 #T -1  (Seconds)
 #P0 0 0 0 0
-#N 6
-#L seq_num  Epoch  Seconds  det  motor  motor_setpoint
-1  1551888078 -1 0.6065306597126334 -1.0 -1.0
+#N 4
+#L motor  Epoch  Seconds  det
+-1.0  1551888078 -1 0.6065306597126334
 
-2  1551888078 -1 1.0 0.0 0.0
+0.0  1551888078 -1 1.0
 
-3  1551888078 -1 0.6065306597126334 1.0 1.0
+1.0  1551888078 -1 0.6065306597126334
 


### PR DESCRIPTION
This adds the ablity to run the following plans in bluesky and generate specfiles that can be opened in PyMca. Tested with PyMca version 5.6.3

- [grid_scan](https://nsls-ii.github.io/bluesky/generated/bluesky.plans.grid_scan.html#bluesky.plans.grid_scan) with 2 motors which is mapped to the spec macro [mesh](https://certif.com/spec_help/mesh.html) 

- [scan](https://nsls-ii.github.io/bluesky/generated/bluesky.plans.scan.html) (but with any number of motors)

- [rel_scan](https://nsls-ii.github.io/bluesky/generated/bluesky.plans.rel_scan.html) (but with any number of motors)

The scan header is correctly formatted as per the spec manual for [mesh](https://certif.com/spec_help/mesh.html) [a2scan,a3scan,a4scan](https://certif.com/spec_help/a2scan.html) and [d2scan, d3scan, d4scan](https://certif.com/spec_help/d2scan.html)

If a grid_scan is performed with more than 2 motors, an error is thrown since this isn't in the spec mesh specification.

Tested by running scans in bluesky and then viewing the output in PyMca and in the case of mesh, with the RegularMeshPlugin. I was not sure how to add tests for this to the pytest files, ideally I'd add a test if the headers created are correct. Any help would be appreciated.

I found that if I try and run pytest on my machine the test against the historical files always fails because the date is calculated from the epoch assuming I am in the US. Otherwise it's correct.